### PR TITLE
chore: verify runtime dependencies

### DIFF
--- a/.github/workflows/enhanced-mobile-testing.yml
+++ b/.github/workflows/enhanced-mobile-testing.yml
@@ -54,6 +54,19 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r requirements.txt
+          pip install -r backend/requirements.txt
+
+      - name: Verify Python imports
+        run: |
+          python - <<'PY'
+import importlib, sys
+packages = ['fastapi', 'pydantic', 'spacy']
+missing = [p for p in packages if importlib.util.find_spec(p) is None]
+if missing:
+    print(f"Missing packages: {', '.join(missing)}")
+    sys.exit(1)
+print('✅ All required packages imported successfully')
+PY
           
       - name: Install frontend dependencies
         working-directory: ./svelte-frontend
@@ -91,10 +104,23 @@ jobs:
           cache-dependency-path: 'svelte-frontend/package-lock.json'
           
       - name: Install dependencies
-        working-directory: ./svelte-frontend
         run: |
-          npm ci
+          pip install -r requirements.txt
+          pip install -r backend/requirements.txt
+          npm ci --prefix svelte-frontend
           npx playwright install --with-deps
+
+      - name: Verify Python imports
+        run: |
+          python - <<'PY'
+import importlib, sys
+packages = ['fastapi', 'pydantic', 'spacy']
+missing = [p for p in packages if importlib.util.find_spec(p) is None]
+if missing:
+    print(f"Missing packages: {', '.join(missing)}")
+    sys.exit(1)
+print('✅ All required packages imported successfully')
+PY
           
       - name: Start backend services
         run: |
@@ -146,9 +172,22 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
+          pip install -r backend/requirements.txt
           cd svelte-frontend
           npm ci
           npx playwright install --with-deps
+
+      - name: Verify Python imports
+        run: |
+          python - <<'PY'
+import importlib, sys
+packages = ['fastapi', 'pydantic', 'spacy']
+missing = [p for p in packages if importlib.util.find_spec(p) is None]
+if missing:
+    print(f"Missing packages: {', '.join(missing)}")
+    sys.exit(1)
+print('✅ All required packages imported successfully')
+PY
           
       - name: Start full GödelOS system
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,13 @@ fastapi>=0.104.0
 jsonschema>=4.18.0
 uvicorn[standard]>=0.24.0
 pydantic>=2.4.0
+pydantic-settings>=2.0
 python-multipart>=0.0.6
 websockets>=11.0.0
 PyYAML>=6.0.1
+aiofiles>=23.2.1
+python-docx>=1.1.0
+PyPDF2>=3.0.1
 
 # Cognitive transparency dependencies
 networkx>=3.1.0

--- a/setup_venv.sh
+++ b/setup_venv.sh
@@ -38,6 +38,17 @@ pip install -r requirements.txt
 echo "Installing dependencies from backend/requirements.txt..."
 pip install -r backend/requirements.txt
 
+echo "Verifying core imports..."
+python - <<'PY'
+import importlib, sys
+packages = ['fastapi', 'pydantic', 'spacy']
+missing = [p for p in packages if importlib.util.find_spec(p) is None]
+if missing:
+    print(f"❌ Missing packages: {', '.join(missing)}")
+    sys.exit(1)
+print("✅ All required packages are available")
+PY
+
 echo ""
 echo "Setup complete! The virtual environment '$VENV_DIR' is ready."
 echo "Remember to activate it in your shell by running: source $VENV_DIR/bin/activate"

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -32,10 +32,12 @@ def check_dependencies():
     """Check if required dependencies are installed."""
     required_packages = [
         "pytest",
-        "pytest-asyncio", 
+        "pytest-asyncio",
         "pytest-cov",
         "requests",
         "fastapi",
+        "pydantic",
+        "spacy",
         "websockets"
     ]
     

--- a/tests/test_dependency_imports.py
+++ b/tests/test_dependency_imports.py
@@ -1,0 +1,23 @@
+"""
+Feature: Ensure critical runtime dependencies are available
+
+Scenario: Importing core packages succeeds
+    Given the runtime environment
+    When importing FastAPI, Pydantic, and spaCy
+    Then they are available without ImportError
+"""
+import importlib
+import pytest
+
+REQUIRED_PACKAGES = ["fastapi", "pydantic", "spacy"]
+
+
+@pytest.mark.unit
+def test_imports():
+    for pkg in REQUIRED_PACKAGES:
+        try:
+            importlib.import_module(pkg)
+            print(f"✅ {pkg} imported")
+        except Exception as exc:
+            pytest.fail(f"❌ {pkg} failed to import: {exc}")
+


### PR DESCRIPTION
## Summary
- add missing runtime packages to requirements
- verify critical Python imports in CI and setup script
- add BDD-style test ensuring FastAPI, Pydantic, and spaCy import

## Testing
- `pip install fastapi pydantic spacy pytest`
- `pytest -q tests/test_dependency_imports.py -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68b378bd6cac8332a9bfff62cbe15528