### PR TITLE
refactor: add service wiring startup

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -41,9 +41,15 @@ from backend.knowledge_models import (
     TextImportRequest, BatchImportRequest, SearchQuery, Category,
     ImportSource
 )
-from backend.knowledge_ingestion import knowledge_ingestion_service
-from backend.knowledge_management import knowledge_management_service
-from backend.knowledge_pipeline_service import knowledge_pipeline_service
+from backend.knowledge_ingestion import (
+    knowledge_ingestion_service as default_knowledge_ingestion_service,
+)
+from backend.knowledge_management import (
+    knowledge_management_service as default_knowledge_management_service,
+)
+from backend.knowledge_pipeline_service import (
+    knowledge_pipeline_service as default_knowledge_pipeline_service,
+)
 from backend.llm_cognitive_driver import get_llm_cognitive_driver
 
 # Configure logging
@@ -53,26 +59,56 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Initialize WebSocket manager early (after logger is defined)
-websocket_manager = WebSocketManager()
+# Global service instances (overridable for testing)
+knowledge_ingestion_service = default_knowledge_ingestion_service
+knowledge_management_service = default_knowledge_management_service
+knowledge_pipeline_service = default_knowledge_pipeline_service
 
-# Set WebSocket manager on services immediately
-logger.info(f"🔍 IMPORT: Setting websocket_manager on services at import time")
-knowledge_ingestion_service.websocket_manager = websocket_manager
-logger.info(f"🔍 IMPORT: WebSocket manager set on knowledge_ingestion_service: {knowledge_ingestion_service.websocket_manager is not None}")
+websocket_manager: Optional[WebSocketManager] = None
 
-# Set knowledge management service reference for real-time updates
-import backend.knowledge_ingestion as ki_module
-ki_module.knowledge_management_service = knowledge_management_service
-logger.info(f"🔍 IMPORT: Connected knowledge ingestion to knowledge management service")
+# Service override storage for tests
+_service_overrides: Dict[str, Any] = {}
 
-# Set websocket manager on knowledge pipeline service
-knowledge_pipeline_service.websocket_manager = websocket_manager
-logger.info(f"🔍 IMPORT: WebSocket manager set on knowledge_pipeline_service")
+
+def startup_services() -> None:
+    """Wire service dependencies, allowing overrides for tests."""
+    global websocket_manager, knowledge_ingestion_service
+    global knowledge_management_service, knowledge_pipeline_service
+
+    ws_override = _service_overrides.get("ws_manager")
+    ingestion_override = _service_overrides.get("ingestion")
+    management_override = _service_overrides.get("management")
+    pipeline_override = _service_overrides.get("pipeline")
+
+    websocket_manager = ws_override or WebSocketManager()
+    knowledge_ingestion_service = ingestion_override or default_knowledge_ingestion_service
+    knowledge_management_service = management_override or default_knowledge_management_service
+    knowledge_pipeline_service = pipeline_override or default_knowledge_pipeline_service
+
+    knowledge_ingestion_service.websocket_manager = websocket_manager
+    import backend.knowledge_ingestion as ki_module
+    ki_module.knowledge_management_service = knowledge_management_service
+    knowledge_pipeline_service.websocket_manager = websocket_manager
+
+    logger.info("🛠️ Services wired during startup")
+
+
+def create_app(
+    ws_manager: Optional[WebSocketManager] = None,
+    ingestion_service: Optional[Any] = None,
+    knowledge_management: Optional[Any] = None,
+    knowledge_pipeline: Optional[Any] = None,
+):
+    """Configure service overrides and return the FastAPI app."""
+    _service_overrides["ws_manager"] = ws_manager
+    _service_overrides["ingestion"] = ingestion_service
+    _service_overrides["management"] = knowledge_management
+    _service_overrides["pipeline"] = knowledge_pipeline
+    return app
+
 
 # Global instances
 godelos_integration: Optional[GödelOSIntegration] = None
-# websocket_manager already initialized above at line 52
 cognitive_streaming_task: Optional[asyncio.Task] = None
 llm_cognitive_driver = None
 
@@ -152,8 +188,9 @@ async def continuous_cognitive_streaming():
 async def lifespan(app: FastAPI):
     """Application lifespan manager."""
     global godelos_integration, cognitive_streaming_task
-    
+
     # Startup
+    startup_services()
     logger.info("🔍 BACKEND DIAGNOSTIC: Starting GödelOS system initialization...")
     try:
         logger.info("🔍 BACKEND DIAGNOSTIC: Creating GödelOS integration instance...")

--- a/tests/backend/test_service_injection.py
+++ b/tests/backend/test_service_injection.py
@@ -1,0 +1,139 @@
+import sys
+import types
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class DummyService:
+    def __init__(self):
+        self.websocket_manager = None
+        self.initialized = False
+
+    async def initialize(self, *args, **kwargs):
+        print("🤖 DummyService initialized")
+        self.initialized = True
+
+    async def shutdown(self):
+        print("👋 DummyService shutdown")
+
+
+class DummyPipeline(DummyService):
+    async def initialize(self, websocket_manager=None):
+        print("🤖 DummyPipeline initialized")
+        self.websocket_manager = websocket_manager
+        self.initialized = True
+
+
+# Stub heavy backend modules before importing main
+ki_module = types.ModuleType("backend.knowledge_ingestion")
+ki_module.knowledge_ingestion_service = DummyService()
+sys.modules["backend.knowledge_ingestion"] = ki_module
+
+km_module = types.ModuleType("backend.knowledge_management")
+km_module.knowledge_management_service = DummyService()
+sys.modules["backend.knowledge_management"] = km_module
+
+kp_module = types.ModuleType("backend.knowledge_pipeline_service")
+kp_module.knowledge_pipeline_service = DummyPipeline()
+sys.modules["backend.knowledge_pipeline_service"] = kp_module
+
+from fastapi import APIRouter
+
+ct_module = types.ModuleType("backend.cognitive_transparency_integration")
+class _CTAPI:
+    router = APIRouter()
+    async def initialize(self, *args, **kwargs):
+        pass
+    async def shutdown(self, *args, **kwargs):
+        pass
+ct_module.cognitive_transparency_api = _CTAPI()
+sys.modules["backend.cognitive_transparency_integration"] = ct_module
+
+eca_module = types.ModuleType("backend.enhanced_cognitive_api")
+eca_module.router = APIRouter()
+async def initialize_enhanced_cognitive(*args, **kwargs):
+    pass
+eca_module.initialize_enhanced_cognitive = initialize_enhanced_cognitive
+sys.modules["backend.enhanced_cognitive_api"] = eca_module
+
+cm_module = types.ModuleType("backend.config_manager")
+def get_config(*args, **kwargs):
+    return {}
+def is_feature_enabled(*args, **kwargs):
+    return False
+cm_module.get_config = get_config
+cm_module.is_feature_enabled = is_feature_enabled
+sys.modules["backend.config_manager"] = cm_module
+
+# Minimal websocket manager stub
+wm_module = types.ModuleType("backend.websocket_manager")
+class WebSocketManager:
+    def __init__(self):
+        self.active_connections = []
+    def has_connections(self):
+        return False
+    async def broadcast(self, msg):
+        pass
+    async def connect(self, websocket):
+        pass
+wm_module.WebSocketManager = WebSocketManager
+sys.modules["backend.websocket_manager"] = wm_module
+
+# Minimal GödelOS integration stub
+gi_module = types.ModuleType("backend.godelos_integration")
+class GödelOSIntegration:
+    async def initialize(self):
+        pass
+    async def shutdown(self):
+        pass
+    async def get_cognitive_state(self):
+        return {}
+gi_module.GödelOSIntegration = GödelOSIntegration
+sys.modules["backend.godelos_integration"] = gi_module
+
+# Stub LLM cognitive driver module
+lcd_module = types.ModuleType("backend.llm_cognitive_driver")
+async def get_llm_cognitive_driver(*args, **kwargs):
+    return None
+lcd_module.get_llm_cognitive_driver = get_llm_cognitive_driver
+sys.modules["backend.llm_cognitive_driver"] = lcd_module
+
+from backend.main import create_app
+
+
+def test_service_injection_allows_mocks():
+    print("Given 🧪 mock services and a fake WebSocket manager")
+    ws_mock = WebSocketManager()
+    ingestion = DummyService()
+    management = DummyService()
+    pipeline = DummyPipeline()
+
+    with patch('backend.main.GödelOSIntegration') as MockIntegration, \
+         patch('backend.main.cognitive_transparency_api.initialize', new=AsyncMock()), \
+         patch('backend.main.cognitive_transparency_api.shutdown', new=AsyncMock()), \
+         patch('backend.main.get_llm_cognitive_driver', new=AsyncMock(return_value=None)):
+        MockIntegration.return_value.initialize = AsyncMock()
+        MockIntegration.return_value.shutdown = AsyncMock()
+        MockIntegration.return_value.get_cognitive_state = AsyncMock(return_value={})
+
+        app = create_app(
+            ws_manager=ws_mock,
+            ingestion_service=ingestion,
+            knowledge_management=management,
+            knowledge_pipeline=pipeline,
+        )
+
+        print("When 🚀 the app starts")
+        with TestClient(app):
+            pass
+
+    create_app()  # Reset overrides for other tests
+
+    print("Then ✅ the mocks are wired without side effects")
+    assert ingestion.websocket_manager is ws_mock
+    assert pipeline.websocket_manager is ws_mock
+    assert ingestion.initialized
+    assert management.initialized
+    assert pipeline.initialized


### PR DESCRIPTION
## Summary
- move WebSocket and knowledge service wiring to startup to avoid import side effects
- allow tests to inject mock services via `create_app`
- add injection test with emoji BDD messages
- use WebSocketManager stub in injection test to prevent attribute errors during streaming

## Testing
- `pytest tests/backend/test_service_injection.py::test_service_injection_allows_mocks -q`


------
https://chatgpt.com/codex/tasks/task_e_68b377e317488332a451dc2f1975802c